### PR TITLE
Copy file from git repository and commit it in the local repository

### DIFF
--- a/docs/reference/kwctl-cli-docs.md
+++ b/docs/reference/kwctl-cli-docs.md
@@ -1,0 +1,486 @@
+# Command-Line Help for `kwctl`
+
+This document contains the help content for the `kwctl` command-line program.
+
+**Command Overview:**
+
+* [`kwctl`↴](#kwctl)
+* [`kwctl annotate`↴](#kwctl-annotate)
+* [`kwctl bench`↴](#kwctl-bench)
+* [`kwctl completions`↴](#kwctl-completions)
+* [`kwctl digest`↴](#kwctl-digest)
+* [`kwctl docs`↴](#kwctl-docs)
+* [`kwctl info`↴](#kwctl-info)
+* [`kwctl inspect`↴](#kwctl-inspect)
+* [`kwctl load`↴](#kwctl-load)
+* [`kwctl policies`↴](#kwctl-policies)
+* [`kwctl pull`↴](#kwctl-pull)
+* [`kwctl push`↴](#kwctl-push)
+* [`kwctl rm`↴](#kwctl-rm)
+* [`kwctl run`↴](#kwctl-run)
+* [`kwctl save`↴](#kwctl-save)
+* [`kwctl scaffold`↴](#kwctl-scaffold)
+* [`kwctl scaffold admission-request`↴](#kwctl-scaffold-admission-request)
+* [`kwctl scaffold artifacthub`↴](#kwctl-scaffold-artifacthub)
+* [`kwctl scaffold manifest`↴](#kwctl-scaffold-manifest)
+* [`kwctl scaffold vap`↴](#kwctl-scaffold-vap)
+* [`kwctl scaffold verification-config`↴](#kwctl-scaffold-verification-config)
+* [`kwctl verify`↴](#kwctl-verify)
+
+## `kwctl`
+
+Tool to manage Kubewarden policies
+
+**Usage:** `kwctl [OPTIONS] <COMMAND>`
+
+###### **Subcommands:**
+
+* `annotate` — Add Kubewarden metadata to a WebAssembly module
+* `bench` — Benchmarks a Kubewarden policy
+* `completions` — Generate shell completions
+* `digest` — Fetch digest from the OCI manifest of a policy
+* `docs` — Generates the markdown documentation for kwctl commands
+* `info` — Display system information
+* `inspect` — Inspect Kubewarden policy
+* `load` — load policies from a tar.gz file
+* `policies` — Lists all downloaded policies
+* `pull` — Pulls a Kubewarden policy from a given URI
+* `push` — Pushes a Kubewarden policy to an OCI registry
+* `rm` — Removes a Kubewarden policy from the store
+* `run` — Runs a Kubewarden policy from a given URI
+* `save` — save policies to a tar.gz file
+* `scaffold` — Scaffold a Kubernetes resource or configuration file
+* `verify` — Verify a Kubewarden policy from a given URI using Sigstore
+
+###### **Options:**
+
+* `-v`, `--verbose <VERBOSE>` — Increase verbosity
+* `--no-color <NO-COLOR>` — Disable colorful output
+
+
+
+## `kwctl annotate`
+
+Add Kubewarden metadata to a WebAssembly module
+
+**Usage:** `kwctl annotate [OPTIONS] --metadata-path <PATH> --output-path <PATH> <wasm-path>`
+
+###### **Arguments:**
+
+* `<WASM-PATH>` — Path to WebAssembly module to be annotated
+
+###### **Options:**
+
+* `-m`, `--metadata-path <PATH>` — File containing the metadata
+* `-o`, `--output-path <PATH>` — Output file
+* `-u`, `--usage-path <PATH>` — File containing the usage information of the policy
+
+
+
+## `kwctl bench`
+
+Benchmarks a Kubewarden policy
+
+**Usage:** `kwctl bench [OPTIONS] --request-path <PATH> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--dump-results-to-disk <DUMP_RESULTS_TO_DISK>` — Puts results in target/tiny-bench/label/.. if target can be found. used for comparing previous runs
+* `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
+
+  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
+
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--measurement-time <SECONDS>` — How long the bench ‘should’ run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed
+* `--num-resamples <NUM>` — How many resamples should be done
+* `--num-samples <NUM>` — How many resamples should be done. Recommended at least 50, above 100 doesn’t seem to yield a significantly different result
+* `--raw <RAW>` — Validate a raw request
+
+  Default value: `false`
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy <-> host capabilities
+   communications to the given file.
+   Useful to be combined later with '--replay-host-capabilities-interactions' flag
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--replay-host-capabilities-interactions <FILE>` — During policy <-> host capabilities exchanges
+   the host replays back the answers found inside of the provided file.
+   This is useful to test policies in a reproducible way, given no external
+   interactions with OCI registries, DNS, Kubernetes are performed.
+* `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+* `--warm-up-time <SECONDS>` — How long the bench should warm up
+
+
+
+## `kwctl completions`
+
+Generate shell completions
+
+**Usage:** `kwctl completions --shell <VALUE>`
+
+###### **Options:**
+
+* `-s`, `--shell <VALUE>` — Shell type
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
+
+
+
+## `kwctl digest`
+
+Fetch digest from the OCI manifest of a policy
+
+**Usage:** `kwctl digest [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl docs`
+
+Generates the markdown documentation for kwctl commands
+
+**Usage:** `kwctl docs --output <FILE>`
+
+###### **Options:**
+
+* `-o`, `--output <FILE>` — path where the documentation file will be stored
+
+
+
+## `kwctl info`
+
+Display system information
+
+**Usage:** `kwctl info`
+
+
+
+## `kwctl inspect`
+
+Inspect Kubewarden policy
+
+**Usage:** `kwctl inspect [OPTIONS] <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-o`, `--output <FORMAT>` — Output format
+
+  Possible values: `yaml`
+
+* `--show-signatures <SHOW-SIGNATURES>` — Show sigstore signatures
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl load`
+
+load policies from a tar.gz file
+
+**Usage:** `kwctl load --input <input>`
+
+###### **Options:**
+
+* `--input <INPUT>` — load policies from tarball
+
+
+
+## `kwctl policies`
+
+Lists all downloaded policies
+
+**Usage:** `kwctl policies`
+
+
+
+## `kwctl pull`
+
+Pulls a Kubewarden policy from a given URI
+
+**Usage:** `kwctl pull [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI. Supported schemes: registry://, https://, file://
+
+###### **Options:**
+
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <DOCKER_CONFIG>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `-o`, `--output-path <PATH>` — Output file. If not provided will be downloaded to the Kubewarden store
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key. Can be repeated multiple times
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl push`
+
+Pushes a Kubewarden policy to an OCI registry
+
+**Usage:** `kwctl push [OPTIONS] <policy> <uri>`
+
+###### **Arguments:**
+
+* `<POLICY>` — Policy to push. Can be the path to a local file, a policy URI or the SHA prefix of a policy in the store.
+* `<URI>` — Policy URI. Supported schemes: registry://
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-f`, `--force <FORCE>` — Push also a policy that is not annotated
+* `-o`, `--output <PATH>` — Output format
+
+  Default value: `text`
+
+  Possible values: `text`, `json`
+
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl rm`
+
+Removes a Kubewarden policy from the store
+
+**Usage:** `kwctl rm <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix
+
+
+
+## `kwctl run`
+
+Runs a Kubewarden policy from a given URI
+
+**Usage:** `kwctl run [OPTIONS] --request-path <PATH> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
+
+  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
+
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--raw <RAW>` — Validate a raw request
+
+  Default value: `false`
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy <-> host capabilities
+   communications to the given file.
+   Useful to be combined later with '--replay-host-capabilities-interactions' flag
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--replay-host-capabilities-interactions <FILE>` — During policy <-> host capabilities exchanges
+   the host replays back the answers found inside of the provided file.
+   This is useful to test policies in a reproducible way, given no external
+   interactions with OCI registries, DNS, Kubernetes are performed.
+* `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl save`
+
+save policies to a tar.gz file
+
+**Usage:** `kwctl save --output <FILE> <policies>...`
+
+###### **Arguments:**
+
+* `<POLICIES>` — list of policies to save
+
+###### **Options:**
+
+* `-o`, `--output <FILE>` — path where the file will be stored
+
+
+
+## `kwctl scaffold`
+
+Scaffold a Kubernetes resource or configuration file
+
+**Usage:** `kwctl scaffold <COMMAND>`
+
+###### **Subcommands:**
+
+* `admission-request` — Scaffold an AdmissionRequest object
+* `artifacthub` — Output an artifacthub-pkg.yml file from a metadata.yml file
+* `manifest` — Output a Kubernetes resource manifest
+* `vap` — Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`
+* `verification-config` — Output a default Sigstore verification configuration file
+
+
+
+## `kwctl scaffold admission-request`
+
+Scaffold an AdmissionRequest object
+
+**Usage:** `kwctl scaffold admission-request [OPTIONS] --operation <TYPE>`
+
+###### **Options:**
+
+* `--object <PATH>` — The file containing the new object being admitted
+* `--old-object <PATH>` — The file containing the existing object
+* `-o`, `--operation <TYPE>` — Kubewarden Custom Resource type
+
+  Possible values: `CREATE`
+
+
+
+
+## `kwctl scaffold artifacthub`
+
+Output an artifacthub-pkg.yml file from a metadata.yml file
+
+**Usage:** `kwctl scaffold artifacthub [OPTIONS] --metadata-path <PATH> --version <VALUE>`
+
+###### **Options:**
+
+* `-m`, `--metadata-path <PATH>` — File containing the metadata of the policy
+* `-o`, `--output <FILE>` — Path where the artifact-pkg.yml file will be stored
+* `-q`, `--questions-path <PATH>` — File containing the questions-ui content of the policy
+* `-v`, `--version <VALUE>` — Semver version of the policy
+
+
+
+## `kwctl scaffold manifest`
+
+Output a Kubernetes resource manifest
+
+**Usage:** `kwctl scaffold manifest [OPTIONS] --type <VALUE> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Uses the policy metadata to define which Kubernetes resources can be accessed by the policy. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <DOCKER_CONFIG>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key. Can be repeated multiple times
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `--title <VALUE>` — Policy title
+* `-t`, `--type <VALUE>` — Kubewarden Custom Resource type
+
+  Possible values: `ClusterAdmissionPolicy`, `AdmissionPolicy`
+
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl scaffold vap`
+
+Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`
+
+**Usage:** `kwctl scaffold vap [OPTIONS] --binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml> --policy <VALIDATING-ADMISSION-POLICY.yaml>`
+
+###### **Options:**
+
+* `-b`, `--binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml>` — The file containining the ValidatingAdmissionPolicyBinding definition
+* `--cel-policy <URI>` — The CEL policy module to use
+
+  Default value: `ghcr.io/kubewarden/policies/cel-policy:latest`
+* `-p`, `--policy <VALIDATING-ADMISSION-POLICY.yaml>` — The file containining the ValidatingAdmissionPolicy definition
+
+
+
+## `kwctl scaffold verification-config`
+
+Output a default Sigstore verification configuration file
+
+**Usage:** `kwctl scaffold verification-config`
+
+
+
+## `kwctl verify`
+
+Verify a Kubewarden policy from a given URI using Sigstore
+
+**Usage:** `kwctl verify [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI. Supported schemes: registry://
+
+###### **Options:**
+
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>


### PR DESCRIPTION



<Actions>
    <action id="9a89a92c23e51d9c00e5146b08dd904e6c5894f8250441cf121dd4726badf6b5">
        <h3>Copy file from git repository and commit it in the local repository</h3>
        <details id="26e61b97b64cfeff24dafda063c8284cd00b599d2c4a907b345e9c5d01ff2f8b">
            <summary>Updates file in target repository</summary>
            <p>1 file(s) updated with &#34;# Command-Line Help for `kwctl`\n\nThis document contains the help content for the `kwctl` command-line program.\n\n**Command Overview:**\n\n* [`kwctl`↴](#kwctl)\n* [`kwctl annotate`↴](#kwctl-annotate)\n* [`kwctl bench`↴](#kwctl-bench)\n* [`kwctl completions`↴](#kwctl-completions)\n* [`kwctl digest`↴](#kwctl-digest)\n* [`kwctl docs`↴](#kwctl-docs)\n* [`kwctl info`↴](#kwctl-info)\n* [`kwctl inspect`↴](#kwctl-inspect)\n* [`kwctl load`↴](#kwctl-load)\n* [`kwctl policies`↴](#kwctl-policies)\n* [`kwctl pull`↴](#kwctl-pull)\n* [`kwctl push`↴](#kwctl-push)\n* [`kwctl rm`↴](#kwctl-rm)\n* [`kwctl run`↴](#kwctl-run)\n* [`kwctl save`↴](#kwctl-save)\n* [`kwctl scaffold`↴](#kwctl-scaffold)\n* [`kwctl scaffold admission-request`↴](#kwctl-scaffold-admission-request)\n* [`kwctl scaffold artifacthub`↴](#kwctl-scaffold-artifacthub)\n* [`kwctl scaffold manifest`↴](#kwctl-scaffold-manifest)\n* [`kwctl scaffold vap`↴](#kwctl-scaffold-vap)\n* [`kwctl scaffold verification-config`↴](#kwctl-scaffold-verification-config)\n* [`kwctl verify`↴](#kwctl-verify)\n\n## `kwctl`\n\nTool to manage Kubewarden policies\n\n**Usage:** `kwctl [OPTIONS] &lt;COMMAND&gt;`\n\n###### **Subcommands:**\n\n* `annotate` — Add Kubewarden metadata to a WebAssembly module\n* `bench` — Benchmarks a Kubewarden policy\n* `completions` — Generate shell completions\n* `digest` — Fetch digest from the OCI manifest of a policy\n* `docs` — Generates the markdown documentation for kwctl commands\n* `info` — Display system information\n* `inspect` — Inspect Kubewarden policy\n* `load` — load policies from a tar.gz file\n* `policies` — Lists all downloaded policies\n* `pull` — Pulls a Kubewarden policy from a given URI\n* `push` — Pushes a Kubewarden policy to an OCI registry\n* `rm` — Removes a Kubewarden policy from the store\n* `run` — Runs a Kubewarden policy from a given URI\n* `save` — save policies to a tar.gz file\n* `scaffold` — Scaffold a Kubernetes resource or configuration file\n* `verify` — Verify a Kubewarden policy from a given URI using Sigstore\n\n###### **Options:**\n\n* `-v`, `--verbose &lt;VERBOSE&gt;` — Increase verbosity\n* `--no-color &lt;NO-COLOR&gt;` — Disable colorful output\n\n\n\n## `kwctl annotate`\n\nAdd Kubewarden metadata to a WebAssembly module\n\n**Usage:** `kwctl annotate [OPTIONS] --metadata-path &lt;PATH&gt; --output-path &lt;PATH&gt; &lt;wasm-path&gt;`\n\n###### **Arguments:**\n\n* `&lt;WASM-PATH&gt;` — Path to WebAssembly module to be annotated\n\n###### **Options:**\n\n* `-m`, `--metadata-path &lt;PATH&gt;` — File containing the metadata\n* `-o`, `--output-path &lt;PATH&gt;` — Output file\n* `-u`, `--usage-path &lt;PATH&gt;` — File containing the usage information of the policy\n\n\n\n## `kwctl bench`\n\nBenchmarks a Kubewarden policy\n\n**Usage:** `kwctl bench [OPTIONS] --request-path &lt;PATH&gt; &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--allow-context-aware &lt;ALLOW-CONTEXT-AWARE&gt;` — Grant access to the Kubernetes resources defined inside of the policy&#39;s `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--disable-wasmtime-cache &lt;DISABLE-WASMTIME-CACHE&gt;` — Turn off usage of wasmtime cache\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--dump-results-to-disk &lt;DUMP_RESULTS_TO_DISK&gt;` — Puts results in target/tiny-bench/label/.. if target can be found. used for comparing previous runs\n* `-e`, `--execution-mode &lt;MODE&gt;` — The runtime to use to execute this policy\n\n  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`\n\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--measurement-time &lt;SECONDS&gt;` — How long the bench ‘should’ run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed\n* `--num-resamples &lt;NUM&gt;` — How many resamples should be done\n* `--num-samples &lt;NUM&gt;` — How many resamples should be done. Recommended at least 50, above 100 doesn’t seem to yield a significantly different result\n* `--raw &lt;RAW&gt;` — Validate a raw request\n\n  Default value: `false`\n* `--record-host-capabilities-interactions &lt;FILE&gt;` — Record all the policy &lt;-&gt; host capabilities\n   communications to the given file.\n   Useful to be combined later with &#39;--replay-host-capabilities-interactions&#39; flag\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key\n* `--replay-host-capabilities-interactions &lt;FILE&gt;` — During policy &lt;-&gt; host capabilities exchanges\n   the host replays back the answers found inside of the provided file.\n   This is useful to test policies in a reproducible way, given no external\n   interactions with OCI registries, DNS, Kubernetes are performed.\n* `-r`, `--request-path &lt;PATH&gt;` — File containing the Kubernetes admission request object in JSON format\n* `--settings-json &lt;VALUE&gt;` — JSON string containing the settings for this policy\n* `-s`, `--settings-path &lt;PATH&gt;` — File containing the settings for this policy\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n* `--warm-up-time &lt;SECONDS&gt;` — How long the bench should warm up\n\n\n\n## `kwctl completions`\n\nGenerate shell completions\n\n**Usage:** `kwctl completions --shell &lt;VALUE&gt;`\n\n###### **Options:**\n\n* `-s`, `--shell &lt;VALUE&gt;` — Shell type\n\n  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`\n\n\n\n\n## `kwctl digest`\n\nFetch digest from the OCI manifest of a policy\n\n**Usage:** `kwctl digest [OPTIONS] &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI&gt;` — Policy URI\n\n###### **Options:**\n\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n\n\n\n## `kwctl docs`\n\nGenerates the markdown documentation for kwctl commands\n\n**Usage:** `kwctl docs --output &lt;FILE&gt;`\n\n###### **Options:**\n\n* `-o`, `--output &lt;FILE&gt;` — path where the documentation file will be stored\n\n\n\n## `kwctl info`\n\nDisplay system information\n\n**Usage:** `kwctl info`\n\n\n\n## `kwctl inspect`\n\nInspect Kubewarden policy\n\n**Usage:** `kwctl inspect [OPTIONS] &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `-o`, `--output &lt;FORMAT&gt;` — Output format\n\n  Possible values: `yaml`\n\n* `--show-signatures &lt;SHOW-SIGNATURES&gt;` — Show sigstore signatures\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n\n\n\n## `kwctl load`\n\nload policies from a tar.gz file\n\n**Usage:** `kwctl load --input &lt;input&gt;`\n\n###### **Options:**\n\n* `--input &lt;INPUT&gt;` — load policies from tarball\n\n\n\n## `kwctl policies`\n\nLists all downloaded policies\n\n**Usage:** `kwctl policies`\n\n\n\n## `kwctl pull`\n\nPulls a Kubewarden policy from a given URI\n\n**Usage:** `kwctl pull [OPTIONS] &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI&gt;` — Policy URI. Supported schemes: registry://, https://, file://\n\n###### **Options:**\n\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--docker-config-json-path &lt;DOCKER_CONFIG&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `-o`, `--output-path &lt;PATH&gt;` — Output file. If not provided will be downloaded to the Kubewarden store\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key. Can be repeated multiple times\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n## `kwctl push`\n\nPushes a Kubewarden policy to an OCI registry\n\n**Usage:** `kwctl push [OPTIONS] &lt;policy&gt; &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;POLICY&gt;` — Policy to push. Can be the path to a local file, a policy URI or the SHA prefix of a policy in the store.\n* `&lt;URI&gt;` — Policy URI. Supported schemes: registry://\n\n###### **Options:**\n\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `-f`, `--force &lt;FORCE&gt;` — Push also a policy that is not annotated\n* `-o`, `--output &lt;PATH&gt;` — Output format\n\n  Default value: `text`\n\n  Possible values: `text`, `json`\n\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n\n\n\n## `kwctl rm`\n\nRemoves a Kubewarden policy from the store\n\n**Usage:** `kwctl rm &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix\n\n\n\n## `kwctl run`\n\nRuns a Kubewarden policy from a given URI\n\n**Usage:** `kwctl run [OPTIONS] --request-path &lt;PATH&gt; &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--allow-context-aware &lt;ALLOW-CONTEXT-AWARE&gt;` — Grant access to the Kubernetes resources defined inside of the policy&#39;s `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--disable-wasmtime-cache &lt;DISABLE-WASMTIME-CACHE&gt;` — Turn off usage of wasmtime cache\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `-e`, `--execution-mode &lt;MODE&gt;` — The runtime to use to execute this policy\n\n  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`\n\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--raw &lt;RAW&gt;` — Validate a raw request\n\n  Default value: `false`\n* `--record-host-capabilities-interactions &lt;FILE&gt;` — Record all the policy &lt;-&gt; host capabilities\n   communications to the given file.\n   Useful to be combined later with &#39;--replay-host-capabilities-interactions&#39; flag\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key\n* `--replay-host-capabilities-interactions &lt;FILE&gt;` — During policy &lt;-&gt; host capabilities exchanges\n   the host replays back the answers found inside of the provided file.\n   This is useful to test policies in a reproducible way, given no external\n   interactions with OCI registries, DNS, Kubernetes are performed.\n* `-r`, `--request-path &lt;PATH&gt;` — File containing the Kubernetes admission request object in JSON format\n* `--settings-json &lt;VALUE&gt;` — JSON string containing the settings for this policy\n* `-s`, `--settings-path &lt;PATH&gt;` — File containing the settings for this policy\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n## `kwctl save`\n\nsave policies to a tar.gz file\n\n**Usage:** `kwctl save --output &lt;FILE&gt; &lt;policies&gt;...`\n\n###### **Arguments:**\n\n* `&lt;POLICIES&gt;` — list of policies to save\n\n###### **Options:**\n\n* `-o`, `--output &lt;FILE&gt;` — path where the file will be stored\n\n\n\n## `kwctl scaffold`\n\nScaffold a Kubernetes resource or configuration file\n\n**Usage:** `kwctl scaffold &lt;COMMAND&gt;`\n\n###### **Subcommands:**\n\n* `admission-request` — Scaffold an AdmissionRequest object\n* `artifacthub` — Output an artifacthub-pkg.yml file from a metadata.yml file\n* `manifest` — Output a Kubernetes resource manifest\n* `vap` — Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`\n* `verification-config` — Output a default Sigstore verification configuration file\n\n\n\n## `kwctl scaffold admission-request`\n\nScaffold an AdmissionRequest object\n\n**Usage:** `kwctl scaffold admission-request [OPTIONS] --operation &lt;TYPE&gt;`\n\n###### **Options:**\n\n* `--object &lt;PATH&gt;` — The file containing the new object being admitted\n* `--old-object &lt;PATH&gt;` — The file containing the existing object\n* `-o`, `--operation &lt;TYPE&gt;` — Kubewarden Custom Resource type\n\n  Possible values: `CREATE`\n\n\n\n\n## `kwctl scaffold artifacthub`\n\nOutput an artifacthub-pkg.yml file from a metadata.yml file\n\n**Usage:** `kwctl scaffold artifacthub [OPTIONS] --metadata-path &lt;PATH&gt; --version &lt;VALUE&gt;`\n\n###### **Options:**\n\n* `-m`, `--metadata-path &lt;PATH&gt;` — File containing the metadata of the policy\n* `-o`, `--output &lt;FILE&gt;` — Path where the artifact-pkg.yml file will be stored\n* `-q`, `--questions-path &lt;PATH&gt;` — File containing the questions-ui content of the policy\n* `-v`, `--version &lt;VALUE&gt;` — Semver version of the policy\n\n\n\n## `kwctl scaffold manifest`\n\nOutput a Kubernetes resource manifest\n\n**Usage:** `kwctl scaffold manifest [OPTIONS] --type &lt;VALUE&gt; &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--allow-context-aware &lt;ALLOW-CONTEXT-AWARE&gt;` — Uses the policy metadata to define which Kubernetes resources can be accessed by the policy. Warning: review the list of resources carefully to avoid abuses. Disabled by default\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--docker-config-json-path &lt;DOCKER_CONFIG&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key. Can be repeated multiple times\n* `--settings-json &lt;VALUE&gt;` — JSON string containing the settings for this policy\n* `-s`, `--settings-path &lt;PATH&gt;` — File containing the settings for this policy\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `--title &lt;VALUE&gt;` — Policy title\n* `-t`, `--type &lt;VALUE&gt;` — Kubewarden Custom Resource type\n\n  Possible values: `ClusterAdmissionPolicy`, `AdmissionPolicy`\n\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n## `kwctl scaffold vap`\n\nConvert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`\n\n**Usage:** `kwctl scaffold vap [OPTIONS] --binding &lt;VALIDATING-ADMISSION-POLICY-BINDING.yaml&gt; --policy &lt;VALIDATING-ADMISSION-POLICY.yaml&gt;`\n\n###### **Options:**\n\n* `-b`, `--binding &lt;VALIDATING-ADMISSION-POLICY-BINDING.yaml&gt;` — The file containining the ValidatingAdmissionPolicyBinding definition\n* `--cel-policy &lt;URI&gt;` — The CEL policy module to use\n\n  Default value: `ghcr.io/kubewarden/policies/cel-policy:latest`\n* `-p`, `--policy &lt;VALIDATING-ADMISSION-POLICY.yaml&gt;` — The file containining the ValidatingAdmissionPolicy definition\n\n\n\n## `kwctl scaffold verification-config`\n\nOutput a default Sigstore verification configuration file\n\n**Usage:** `kwctl scaffold verification-config`\n\n\n\n## `kwctl verify`\n\nVerify a Kubewarden policy from a given URI using Sigstore\n\n**Usage:** `kwctl verify [OPTIONS] &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI&gt;` — Policy URI. Supported schemes: registry://\n\n###### **Options:**\n\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n&lt;hr/&gt;\n\n&lt;small&gt;&lt;i&gt;\n    This document was generated automatically by\n    &lt;a href=\&#34;https://crates.io/crates/clap-markdown\&#34;&gt;&lt;code&gt;clap-markdown&lt;/code&gt;&lt;/a&gt;.\n&lt;/i&gt;&lt;/small&gt;\n&#34;:&#xA;&#x9;* docs/reference/kwctl-cli-docs.md&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

