### PR TITLE
Copy files from jvanz/kwctl

### DIFF
--- a/docs/reference/kwctl-cli.md
+++ b/docs/reference/kwctl-cli.md
@@ -1,0 +1,486 @@
+# Command-Line Help for `kwctl`
+
+This document contains the help content for the `kwctl` command-line program.
+
+**Command Overview:**
+
+* [`kwctl`↴](#kwctl)
+* [`kwctl annotate`↴](#kwctl-annotate)
+* [`kwctl bench`↴](#kwctl-bench)
+* [`kwctl completions`↴](#kwctl-completions)
+* [`kwctl digest`↴](#kwctl-digest)
+* [`kwctl docs`↴](#kwctl-docs)
+* [`kwctl info`↴](#kwctl-info)
+* [`kwctl inspect`↴](#kwctl-inspect)
+* [`kwctl load`↴](#kwctl-load)
+* [`kwctl policies`↴](#kwctl-policies)
+* [`kwctl pull`↴](#kwctl-pull)
+* [`kwctl push`↴](#kwctl-push)
+* [`kwctl rm`↴](#kwctl-rm)
+* [`kwctl run`↴](#kwctl-run)
+* [`kwctl save`↴](#kwctl-save)
+* [`kwctl scaffold`↴](#kwctl-scaffold)
+* [`kwctl scaffold admission-request`↴](#kwctl-scaffold-admission-request)
+* [`kwctl scaffold artifacthub`↴](#kwctl-scaffold-artifacthub)
+* [`kwctl scaffold manifest`↴](#kwctl-scaffold-manifest)
+* [`kwctl scaffold vap`↴](#kwctl-scaffold-vap)
+* [`kwctl scaffold verification-config`↴](#kwctl-scaffold-verification-config)
+* [`kwctl verify`↴](#kwctl-verify)
+
+## `kwctl`
+
+Tool to manage Kubewarden policies
+
+**Usage:** `kwctl [OPTIONS] <COMMAND>`
+
+###### **Subcommands:**
+
+* `annotate` — Add Kubewarden metadata to a WebAssembly module
+* `bench` — Benchmarks a Kubewarden policy
+* `completions` — Generate shell completions
+* `digest` — Fetch digest from the OCI manifest of a policy
+* `docs` — Generates the markdown documentation for kwctl commands
+* `info` — Display system information
+* `inspect` — Inspect Kubewarden policy
+* `load` — load policies from a tar.gz file
+* `policies` — Lists all downloaded policies
+* `pull` — Pulls a Kubewarden policy from a given URI
+* `push` — Pushes a Kubewarden policy to an OCI registry
+* `rm` — Removes a Kubewarden policy from the store
+* `run` — Runs a Kubewarden policy from a given URI
+* `save` — save policies to a tar.gz file
+* `scaffold` — Scaffold a Kubernetes resource or configuration file
+* `verify` — Verify a Kubewarden policy from a given URI using Sigstore
+
+###### **Options:**
+
+* `-v`, `--verbose <VERBOSE>` — Increase verbosity
+* `--no-color <NO-COLOR>` — Disable colorful output
+
+
+
+## `kwctl annotate`
+
+Add Kubewarden metadata to a WebAssembly module
+
+**Usage:** `kwctl annotate [OPTIONS] --metadata-path <PATH> --output-path <PATH> <wasm-path>`
+
+###### **Arguments:**
+
+* `<WASM-PATH>` — Path to WebAssembly module to be annotated
+
+###### **Options:**
+
+* `-m`, `--metadata-path <PATH>` — File containing the metadata
+* `-o`, `--output-path <PATH>` — Output file
+* `-u`, `--usage-path <PATH>` — File containing the usage information of the policy
+
+
+
+## `kwctl bench`
+
+Benchmarks a Kubewarden policy
+
+**Usage:** `kwctl bench [OPTIONS] --request-path <PATH> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--dump-results-to-disk <DUMP_RESULTS_TO_DISK>` — Puts results in target/tiny-bench/label/.. if target can be found. used for comparing previous runs
+* `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
+
+  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
+
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--measurement-time <SECONDS>` — How long the bench ‘should’ run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed
+* `--num-resamples <NUM>` — How many resamples should be done
+* `--num-samples <NUM>` — How many resamples should be done. Recommended at least 50, above 100 doesn’t seem to yield a significantly different result
+* `--raw <RAW>` — Validate a raw request
+
+  Default value: `false`
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy and host capabilities
+   communications to the given file.
+   Useful to be combined later with '--replay-host-capabilities-interactions' flag
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--replay-host-capabilities-interactions <FILE>` — During policy and host capabilities exchanges
+   the host replays back the answers found inside of the provided file.
+   This is useful to test policies in a reproducible way, given no external
+   interactions with OCI registries, DNS, Kubernetes are performed.
+* `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+* `--warm-up-time <SECONDS>` — How long the bench should warm up
+
+
+
+## `kwctl completions`
+
+Generate shell completions
+
+**Usage:** `kwctl completions --shell <VALUE>`
+
+###### **Options:**
+
+* `-s`, `--shell <VALUE>` — Shell type
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
+
+
+
+## `kwctl digest`
+
+Fetch digest from the OCI manifest of a policy
+
+**Usage:** `kwctl digest [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl docs`
+
+Generates the markdown documentation for kwctl commands
+
+**Usage:** `kwctl docs --output <FILE>`
+
+###### **Options:**
+
+* `-o`, `--output <FILE>` — path where the documentation file will be stored
+
+
+
+## `kwctl info`
+
+Display system information
+
+**Usage:** `kwctl info`
+
+
+
+## `kwctl inspect`
+
+Inspect Kubewarden policy
+
+**Usage:** `kwctl inspect [OPTIONS] <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-o`, `--output <FORMAT>` — Output format
+
+  Possible values: `yaml`
+
+* `--show-signatures <SHOW-SIGNATURES>` — Show sigstore signatures
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl load`
+
+load policies from a tar.gz file
+
+**Usage:** `kwctl load --input <input>`
+
+###### **Options:**
+
+* `--input <INPUT>` — load policies from tarball
+
+
+
+## `kwctl policies`
+
+Lists all downloaded policies
+
+**Usage:** `kwctl policies`
+
+
+
+## `kwctl pull`
+
+Pulls a Kubewarden policy from a given URI
+
+**Usage:** `kwctl pull [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI. Supported schemes: registry://, https://, file://
+
+###### **Options:**
+
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <DOCKER_CONFIG>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `-o`, `--output-path <PATH>` — Output file. If not provided will be downloaded to the Kubewarden store
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key. Can be repeated multiple times
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl push`
+
+Pushes a Kubewarden policy to an OCI registry
+
+**Usage:** `kwctl push [OPTIONS] <policy> <uri>`
+
+###### **Arguments:**
+
+* `<POLICY>` — Policy to push. Can be the path to a local file, a policy URI or the SHA prefix of a policy in the store.
+* `<URI>` — Policy URI. Supported schemes: registry://
+
+###### **Options:**
+
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-f`, `--force <FORCE>` — Push also a policy that is not annotated
+* `-o`, `--output <PATH>` — Output format
+
+  Default value: `text`
+
+  Possible values: `text`, `json`
+
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+
+
+
+## `kwctl rm`
+
+Removes a Kubewarden policy from the store
+
+**Usage:** `kwctl rm <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix
+
+
+
+## `kwctl run`
+
+Runs a Kubewarden policy from a given URI
+
+**Usage:** `kwctl run [OPTIONS] --request-path <PATH> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `-e`, `--execution-mode <MODE>` — The runtime to use to execute this policy
+
+  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`
+
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--raw <RAW>` — Validate a raw request
+
+  Default value: `false`
+* `--record-host-capabilities-interactions <FILE>` — Record all the policy and host capabilities
+   communications to the given file.
+   Useful to be combined later with '--replay-host-capabilities-interactions' flag
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--replay-host-capabilities-interactions <FILE>` — During policy and host capabilities exchanges
+   the host replays back the answers found inside of the provided file.
+   This is useful to test policies in a reproducible way, given no external
+   interactions with OCI registries, DNS, Kubernetes are performed.
+* `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl save`
+
+save policies to a tar.gz file
+
+**Usage:** `kwctl save --output <FILE> <policies>...`
+
+###### **Arguments:**
+
+* `<POLICIES>` — list of policies to save
+
+###### **Options:**
+
+* `-o`, `--output <FILE>` — path where the file will be stored
+
+
+
+## `kwctl scaffold`
+
+Scaffold a Kubernetes resource or configuration file
+
+**Usage:** `kwctl scaffold <COMMAND>`
+
+###### **Subcommands:**
+
+* `admission-request` — Scaffold an AdmissionRequest object
+* `artifacthub` — Output an artifacthub-pkg.yml file from a metadata.yml file
+* `manifest` — Output a Kubernetes resource manifest
+* `vap` — Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`
+* `verification-config` — Output a default Sigstore verification configuration file
+
+
+
+## `kwctl scaffold admission-request`
+
+Scaffold an AdmissionRequest object
+
+**Usage:** `kwctl scaffold admission-request [OPTIONS] --operation <TYPE>`
+
+###### **Options:**
+
+* `--object <PATH>` — The file containing the new object being admitted
+* `--old-object <PATH>` — The file containing the existing object
+* `-o`, `--operation <TYPE>` — Kubewarden Custom Resource type
+
+  Possible values: `CREATE`
+
+
+
+
+## `kwctl scaffold artifacthub`
+
+Output an artifacthub-pkg.yml file from a metadata.yml file
+
+**Usage:** `kwctl scaffold artifacthub [OPTIONS] --metadata-path <PATH> --version <VALUE>`
+
+###### **Options:**
+
+* `-m`, `--metadata-path <PATH>` — File containing the metadata of the policy
+* `-o`, `--output <FILE>` — Path where the artifact-pkg.yml file will be stored
+* `-q`, `--questions-path <PATH>` — File containing the questions-ui content of the policy
+* `-v`, `--version <VALUE>` — Semver version of the policy
+
+
+
+## `kwctl scaffold manifest`
+
+Output a Kubernetes resource manifest
+
+**Usage:** `kwctl scaffold manifest [OPTIONS] --type <VALUE> <uri_or_sha_prefix>`
+
+###### **Arguments:**
+
+* `<URI_OR_SHA_PREFIX>` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.
+
+###### **Options:**
+
+* `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Uses the policy metadata to define which Kubernetes resources can be accessed by the policy. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <DOCKER_CONFIG>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key. Can be repeated multiple times
+* `--settings-json <VALUE>` — JSON string containing the settings for this policy
+* `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `--title <VALUE>` — Policy title
+* `-t`, `--type <VALUE>` — Kubewarden Custom Resource type
+
+  Possible values: `ClusterAdmissionPolicy`, `AdmissionPolicy`
+
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+## `kwctl scaffold vap`
+
+Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`
+
+**Usage:** `kwctl scaffold vap [OPTIONS] --binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml> --policy <VALIDATING-ADMISSION-POLICY.yaml>`
+
+###### **Options:**
+
+* `-b`, `--binding <VALIDATING-ADMISSION-POLICY-BINDING.yaml>` — The file containining the ValidatingAdmissionPolicyBinding definition
+* `--cel-policy <URI>` — The CEL policy module to use
+
+  Default value: `ghcr.io/kubewarden/policies/cel-policy:latest`
+* `-p`, `--policy <VALIDATING-ADMISSION-POLICY.yaml>` — The file containining the ValidatingAdmissionPolicy definition
+
+
+
+## `kwctl scaffold verification-config`
+
+Output a default Sigstore verification configuration file
+
+**Usage:** `kwctl scaffold verification-config`
+
+
+
+## `kwctl verify`
+
+Verify a Kubewarden policy from a given URI using Sigstore
+
+**Usage:** `kwctl verify [OPTIONS] <uri>`
+
+###### **Arguments:**
+
+* `<URI>` — Policy URI. Supported schemes: registry://
+
+###### **Options:**
+
+* `--cert-email <VALUE>` — Expected email in Fulcio certificate
+* `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
+* `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
+* `--fulcio-cert-path <PATH>` — Path to the Fulcio certificate. Can be repeated multiple times
+* `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
+* `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--rekor-public-key-path <PATH>` — Path to the Rekor public key
+* `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
+* `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
+* `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
+* `-k`, `--verification-key <PATH>` — Path to key used to verify the policy. Can be repeated multiple times
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>

--- a/docs/reference/kwctl-readme.md
+++ b/docs/reference/kwctl-readme.md
@@ -1,0 +1,359 @@
+[![Kubewarden Core Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-core.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#core-scope)
+[![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9180/badge)](https://www.bestpractices.dev/projects/9180)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fkwctl.svg?type=shield)](https://app.fossa.com/projects/cjustom%2B25850%2Fgithub.com%2Fkubewarden%2Fkwctl?ref=badge_shield)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubewarden/kwctl/badge)](https://scorecard.dev/viewer/?uri=github.com/kubewarden/kwctl)
+
+# `kwctl`
+
+`kwctl` is the go-to CLI tool for [Kubewarden](https://kubewarden.io)
+users.
+
+Think of it as the `docker` CLI tool if you were working with
+containers.
+
+## How does `kwctl` help me?
+
+### As a policy author
+
+- e2e testing of your policy. Test your policy against crafted
+  Kubernetes requests, and ensure your policy behaves as you
+  expect. You can even test context-aware policies, that require
+  access to a running cluster.
+
+- Embed metadata in your Wasm module, so the binary is annotated with
+  the permissions it needs to execute.
+
+- Publish policies to OCI registries.
+
+- Generate initial `ClusterAdmissionPolicy` scaffolding for your
+  policy.
+
+### As a cluster administrator
+
+- Inspect remote policies. Given a policy in an OCI registry, or in an
+  HTTP server, show all static information about the policy.
+
+- Dry-run of a policy in your cluster. Test the policy against crafted
+  Kubernetes requests, and ensure the policy behaves as you expect
+  given the input data you provide. You can even test context-aware
+  policies, that require access to a running cluster, also in a
+  dry-run mode.
+
+- Generate `ClusterAdmissionPolicy` scaffolding for a given policy.
+
+### Everyone
+
+- The UX of this tool is intended to be as easy and intuitive as
+  possible.
+
+## Install
+
+Built binaries for `Linux x86_64`, `Windows x86_64`, `MacOS x86_64` and `MacOS
+aarch64 (M1)` are available in [GH Releases](https://github.com/kubewarden/kwctl/releases).
+
+There is also:
+
+- Community-created [Homebrew 🍺 formula for kwctl](https://formulae.brew.sh/formula/kwctl)
+- Community-created [AUR 🐧 package](https://aur.archlinux.org/packages/kwctl-bin)
+
+## Usage
+
+These are the commands currently supported by kwctl.
+
+If you want a complete list of the available commands, you can read the 
+[cli-docs.md](./cli-docs.md) file.
+
+### List policies
+
+The list of policies downloaded on the local machine can be
+obtained by doing:
+
+```console
+kwctl policies
+```
+
+### Download policies
+
+Policies can be downloaded using the `pull` command.
+
+The name of the policy must be expressed as a url with one of the
+following protocols:
+
+- `http://`: pull from a HTTP server
+- `https://`: pull from a HTTPS server
+- `registry://`: pull from an OCI registry
+
+Pulling from a registry, by tag:
+
+```console
+kwctl pull registry://ghcr.io/kubewarden/policies/psp-capabilities:latest
+```
+
+It's possible to pull from a registry using an immutable reference (in the
+same way as with regular container images):
+
+```console
+kwctl pull registry://ghcr.io/kubewarden/policies/psp-capabilities@sha256:61ef63621fa5be8e422881d96d05edfef810992fbf9468e35d1fa5ae815bd97c
+```
+
+Note well, the shasum is the digest of the OCI artifact containig the policy.
+This value can be obtained using a tool like [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md):
+
+```console
+crane digest ghcr.io/kubewarden/policies/psp-capabilities:v0.1.6
+```
+
+### Run a policy locally
+
+`kwctl` can be used to run a policy locally, outside of Kubernetes. This can be used
+to quickly evaluate a policy and find the right settings for it.
+
+The evalution is done against a pre-recorded [`AdmissionReview`](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request).
+
+Running a policy locally:
+
+```console
+kwctl run \
+  --settings-json '{"constrained_labels": {"owner": ".*"}}' \
+  -r test_data/ingress.json \
+  registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5
+```
+
+Policy configuration can be passed on the CLI via the `--settings-json` flag
+or can be loaded from the disk via the `--settings-path` flag.
+
+#### Scaffold AdmissionReview from a Kubernetes resource
+
+It's possible to scaffold an `AdmissionReview` object from a Kubernetes resource:
+
+```console
+kwctl scaffold \
+  admission-request \
+  --operation CREATE \
+  --object ingress.yaml
+```
+
+The output of the above command can be used by the `run` command.
+
+### Annotate a policy
+
+Kubewarden policies are WebAssembly module, which must contain some
+Kubewarden-spefic metadata.
+
+The act of adding metadata to the policy is done by the policy author, right
+before policy distribution.
+
+The `kwctl annotate` command can be used to perform this operation.
+
+### Inspect a policy
+
+The metadata attached to a policy, plus other details can be seen via the
+`kwctl inspect` command.
+
+This command works against a policy that has been previously downloaded.
+
+### Publish a policy
+
+`kwctl` can be used to publish a local policy into an OCI registry. This is done
+via the `push` sub-command.
+
+The `push` sub-command can also be used to copy a policy into another registry:
+
+```console
+kwctl push registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5 \
+  registry://registry.local.lan/kubewarden/safe-labels:v0.1.5
+```
+
+The above command copies a local policy that was downloaded from the GitHub
+Container Registry, into a local registry.
+
+> **Note well:** the policy must be previously downloaded locally via `kwctl pull`
+
+### Remove a local policy
+
+Local policies can be removed via the `rm` sub-command:
+
+```console
+kwctl rm <name of the policy>
+```
+
+### Scaffold Kubernetes Custom Resources
+
+Kubewarden policies are enforced on Kubernetes clusters by using
+special Custom Resources provided by our [Kubernetes integration](https://docs.kubewarden.io/quick-start.html#kubewarden-policies).
+
+The `manifest` sub-command can be used to quickly scaffold the definition of
+Kubewarden Custom Resources.
+
+The manifest command shares some of the arguments of the `run` command, it's
+typical to test a policy locally via the `kwctl run` command and then, once
+satisfied about the policy settings, create a deployment manifest for it via
+the `manifest` command.
+
+Step #1, find the right policy settings:
+
+```console
+kwctl run \
+  --settings-json '{"constrained_labels": {"owner": ".*"}}' \
+  -r test_data/ingress.json \
+  registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5
+```
+
+Step #2, generate a manifest to enforce the policy inside of a
+Kubernetes cluster:
+
+```console
+kwctl manifest\
+  --settings-json '{"constrained_labels": {"owner": ".*"}}' \
+  -t ClusterAdmissionPolicy \
+  registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5
+```
+
+This will produce the following output:
+
+```yaml
+---
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: generated-policy
+spec:
+  module: "registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5"
+  settings:
+    constrained_labels:
+      owner: ".*"
+  rules:
+    - apiGroups:
+        - "*"
+      apiVersions:
+        - "*"
+      resources:
+        - "*"
+      operations:
+        - CREATE
+        - UPDATE
+  mutating: false
+```
+
+Which can then be customized by hand, and then applied into a Kubernetes cluster.
+
+### Shell completion
+
+`kwctl` can generate autocompletion scripts for the following shells:
+
+- bash
+- elvish
+- fish
+- powershell
+- zsh
+
+The completion script can be generated with the following command:
+
+```console
+$ kwctl completions -s <SHELL>
+```
+
+The command will print to the stdout the completion script.
+
+#### Bash
+
+To load completions in your current shell session:
+
+```console
+$ source <(kwctl completions -s bash)
+```
+
+To load completions for every new session, execute once:
+
+- Linux: `$ kwctl completions -s bash > /etc/bash_completion.d/kwctl`
+- MacOS: `$ kwctl completions -s bash > /usr/local/etc/bash_completion.d/kwctl`
+
+You will need to start a new shell for this setup to take effect.
+
+#### Fish
+
+To load completions in your current shell session:
+
+```console
+$ kwctl completions -s fish | source
+```
+
+To load completions for every new session, execute once:
+
+```console
+$ kwctl completions -s fish > ~/.config/fish/completions/kwctl.fish
+```
+
+You will need to start a new shell for this setup to take effect.
+
+#### Zsh
+
+To load completions in your current shell session:
+
+```console
+$ source <(kwctl completions -s zsh)
+```
+
+To load completions for every new session, execute once:
+
+```console
+$ kwctl completions -s zsh > "${fpath[1]}/_kwctl"
+```
+
+##### Oh My Zsh users
+
+These steps are required by [oh-my-zsh](https://ohmyz.sh/) users:
+
+```console
+$ print -l $fpath | grep '.oh-my-zsh/completions'
+$ mkdir ~/.oh-my-zsh/completions
+$ kwctl completions -s zsh > ~/.oh-my-zsh/completions/_kwctl
+rm ~/.zcompdump*
+```
+
+Then start a new shell or run `source ~/.zshrc` once.
+
+## Verify kwctl binaries
+
+kwctl binaries are signed using [Sigstore's blog signing](https://docs.sigstore.dev/signing/signing_with_blobs/).
+When you download a [kwctl release](https://github.com/kubewarden/kwctl/releases/) each zip file contains two
+files that can be used for verification: `kwctl.sig` and `kwctl.pem`.
+
+In order to verify kwctl you need cosign installed, and then execute the following command:
+
+```
+cosign verify-blob \
+  --signature kwctl-linux-x86_64.sig \
+  --cert kwctl-linux-x86_64.pem kwctl-linux-x86_64 \
+  --certificate-identity-regexp 'https://github.com/kubewarden/*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+The output should be:
+
+```
+Verified OK
+```
+
+# Software bill of materials & provenance
+
+Kwctl has its software bill of materials (SBOM) published every release. They
+follow the [SPDX](https://spdx.dev/) format, you can find them together with
+the signature and certificate used to sign it in the [releases
+assets](https://github.com/kubewarden/kwctl/releases).
+
+The build [Provenance](https://slsa.dev/spec/v1.0/provenance) files are
+following the [SLSA](https://slsa.dev/provenance/v0.2#schema) provenance schema
+and are accesible at the GitHub Actions'
+[provenance](https://github.com/kubewarden/kwctl/attestations) tab. For
+information on their format and how to verify them, see the [GitHub
+documentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline).
+
+## Security disclosure
+
+See [SECURITY.md](https://github.com/kubewarden/community/blob/main/SECURITY.md) on the kubewarden/community repo.
+
+## Changelog
+
+See [GitHub Releases content](https://github.com/kubewarden/kwctl/releases).


### PR DESCRIPTION



<Actions>
    <action id="7ef4a0265552844622866af3a750ee6f0044c864c0f57858c0ca337005fc5df8">
        <h3>Copy files from jvanz/kwctl</h3>
        <details id="1d2bdb201e143fb6817c3c58f20e4704bcd73c5fd7a4d46896e12404a323ff56">
            <summary>Updates file in target repository</summary>
            <p>1 file(s) updated with &#34;[![Kubewarden Core Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-core.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#core-scope)\n[![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)\n[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9180/badge)](https://www.bestpractices.dev/projects/9180)\n[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Fkwctl.svg?type=shield)](https://app.fossa.com/projects/cjustom%2B25850%2Fgithub.com%2Fkubewarden%2Fkwctl?ref=badge_shield)\n[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubewarden/kwctl/badge)](https://scorecard.dev/viewer/?uri=github.com/kubewarden/kwctl)\n\n# `kwctl`\n\n`kwctl` is the go-to CLI tool for [Kubewarden](https://kubewarden.io)\nusers.\n\nThink of it as the `docker` CLI tool if you were working with\ncontainers.\n\n## How does `kwctl` help me?\n\n### As a policy author\n\n- e2e testing of your policy. Test your policy against crafted\n  Kubernetes requests, and ensure your policy behaves as you\n  expect. You can even test context-aware policies, that require\n  access to a running cluster.\n\n- Embed metadata in your Wasm module, so the binary is annotated with\n  the permissions it needs to execute.\n\n- Publish policies to OCI registries.\n\n- Generate initial `ClusterAdmissionPolicy` scaffolding for your\n  policy.\n\n### As a cluster administrator\n\n- Inspect remote policies. Given a policy in an OCI registry, or in an\n  HTTP server, show all static information about the policy.\n\n- Dry-run of a policy in your cluster. Test the policy against crafted\n  Kubernetes requests, and ensure the policy behaves as you expect\n  given the input data you provide. You can even test context-aware\n  policies, that require access to a running cluster, also in a\n  dry-run mode.\n\n- Generate `ClusterAdmissionPolicy` scaffolding for a given policy.\n\n### Everyone\n\n- The UX of this tool is intended to be as easy and intuitive as\n  possible.\n\n## Install\n\nBuilt binaries for `Linux x86_64`, `Windows x86_64`, `MacOS x86_64` and `MacOS\naarch64 (M1)` are available in [GH Releases](https://github.com/kubewarden/kwctl/releases).\n\nThere is also:\n\n- Community-created [Homebrew 🍺 formula for kwctl](https://formulae.brew.sh/formula/kwctl)\n- Community-created [AUR 🐧 package](https://aur.archlinux.org/packages/kwctl-bin)\n\n## Usage\n\nThese are the commands currently supported by kwctl.\n\nIf you want a complete list of the available commands, you can read the \n[cli-docs.md](./cli-docs.md) file.\n\n### List policies\n\nThe list of policies downloaded on the local machine can be\nobtained by doing:\n\n```console\nkwctl policies\n```\n\n### Download policies\n\nPolicies can be downloaded using the `pull` command.\n\nThe name of the policy must be expressed as a url with one of the\nfollowing protocols:\n\n- `http://`: pull from a HTTP server\n- `https://`: pull from a HTTPS server\n- `registry://`: pull from an OCI registry\n\nPulling from a registry, by tag:\n\n```console\nkwctl pull registry://ghcr.io/kubewarden/policies/psp-capabilities:latest\n```\n\nIt&#39;s possible to pull from a registry using an immutable reference (in the\nsame way as with regular container images):\n\n```console\nkwctl pull registry://ghcr.io/kubewarden/policies/psp-capabilities@sha256:61ef63621fa5be8e422881d96d05edfef810992fbf9468e35d1fa5ae815bd97c\n```\n\nNote well, the shasum is the digest of the OCI artifact containig the policy.\nThis value can be obtained using a tool like [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md):\n\n```console\ncrane digest ghcr.io/kubewarden/policies/psp-capabilities:v0.1.6\n```\n\n### Run a policy locally\n\n`kwctl` can be used to run a policy locally, outside of Kubernetes. This can be used\nto quickly evaluate a policy and find the right settings for it.\n\nThe evalution is done against a pre-recorded [`AdmissionReview`](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request).\n\nRunning a policy locally:\n\n```console\nkwctl run \\\n  --settings-json &#39;{\&#34;constrained_labels\&#34;: {\&#34;owner\&#34;: \&#34;.*\&#34;}}&#39; \\\n  -r test_data/ingress.json \\\n  registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5\n```\n\nPolicy configuration can be passed on the CLI via the `--settings-json` flag\nor can be loaded from the disk via the `--settings-path` flag.\n\n#### Scaffold AdmissionReview from a Kubernetes resource\n\nIt&#39;s possible to scaffold an `AdmissionReview` object from a Kubernetes resource:\n\n```console\nkwctl scaffold \\\n  admission-request \\\n  --operation CREATE \\\n  --object ingress.yaml\n```\n\nThe output of the above command can be used by the `run` command.\n\n### Annotate a policy\n\nKubewarden policies are WebAssembly module, which must contain some\nKubewarden-spefic metadata.\n\nThe act of adding metadata to the policy is done by the policy author, right\nbefore policy distribution.\n\nThe `kwctl annotate` command can be used to perform this operation.\n\n### Inspect a policy\n\nThe metadata attached to a policy, plus other details can be seen via the\n`kwctl inspect` command.\n\nThis command works against a policy that has been previously downloaded.\n\n### Publish a policy\n\n`kwctl` can be used to publish a local policy into an OCI registry. This is done\nvia the `push` sub-command.\n\nThe `push` sub-command can also be used to copy a policy into another registry:\n\n```console\nkwctl push registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5 \\\n  registry://registry.local.lan/kubewarden/safe-labels:v0.1.5\n```\n\nThe above command copies a local policy that was downloaded from the GitHub\nContainer Registry, into a local registry.\n\n&gt; **Note well:** the policy must be previously downloaded locally via `kwctl pull`\n\n### Remove a local policy\n\nLocal policies can be removed via the `rm` sub-command:\n\n```console\nkwctl rm &lt;name of the policy&gt;\n```\n\n### Scaffold Kubernetes Custom Resources\n\nKubewarden policies are enforced on Kubernetes clusters by using\nspecial Custom Resources provided by our [Kubernetes integration](https://docs.kubewarden.io/quick-start.html#kubewarden-policies).\n\nThe `manifest` sub-command can be used to quickly scaffold the definition of\nKubewarden Custom Resources.\n\nThe manifest command shares some of the arguments of the `run` command, it&#39;s\ntypical to test a policy locally via the `kwctl run` command and then, once\nsatisfied about the policy settings, create a deployment manifest for it via\nthe `manifest` command.\n\nStep #1, find the right policy settings:\n\n```console\nkwctl run \\\n  --settings-json &#39;{\&#34;constrained_labels\&#34;: {\&#34;owner\&#34;: \&#34;.*\&#34;}}&#39; \\\n  -r test_data/ingress.json \\\n  registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5\n```\n\nStep #2, generate a manifest to enforce the policy inside of a\nKubernetes cluster:\n\n```console\nkwctl manifest\\\n  --settings-json &#39;{\&#34;constrained_labels\&#34;: {\&#34;owner\&#34;: \&#34;.*\&#34;}}&#39; \\\n  -t ClusterAdmissionPolicy \\\n  registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5\n```\n\nThis will produce the following output:\n\n```yaml\n---\napiVersion: policies.kubewarden.io/v1\nkind: ClusterAdmissionPolicy\nmetadata:\n  name: generated-policy\nspec:\n  module: \&#34;registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5\&#34;\n  settings:\n    constrained_labels:\n      owner: \&#34;.*\&#34;\n  rules:\n    - apiGroups:\n        - \&#34;*\&#34;\n      apiVersions:\n        - \&#34;*\&#34;\n      resources:\n        - \&#34;*\&#34;\n      operations:\n        - CREATE\n        - UPDATE\n  mutating: false\n```\n\nWhich can then be customized by hand, and then applied into a Kubernetes cluster.\n\n### Shell completion\n\n`kwctl` can generate autocompletion scripts for the following shells:\n\n- bash\n- elvish\n- fish\n- powershell\n- zsh\n\nThe completion script can be generated with the following command:\n\n```console\n$ kwctl completions -s &lt;SHELL&gt;\n```\n\nThe command will print to the stdout the completion script.\n\n#### Bash\n\nTo load completions in your current shell session:\n\n```console\n$ source &lt;(kwctl completions -s bash)\n```\n\nTo load completions for every new session, execute once:\n\n- Linux: `$ kwctl completions -s bash &gt; /etc/bash_completion.d/kwctl`\n- MacOS: `$ kwctl completions -s bash &gt; /usr/local/etc/bash_completion.d/kwctl`\n\nYou will need to start a new shell for this setup to take effect.\n\n#### Fish\n\nTo load completions in your current shell session:\n\n```console\n$ kwctl completions -s fish | source\n```\n\nTo load completions for every new session, execute once:\n\n```console\n$ kwctl completions -s fish &gt; ~/.config/fish/completions/kwctl.fish\n```\n\nYou will need to start a new shell for this setup to take effect.\n\n#### Zsh\n\nTo load completions in your current shell session:\n\n```console\n$ source &lt;(kwctl completions -s zsh)\n```\n\nTo load completions for every new session, execute once:\n\n```console\n$ kwctl completions -s zsh &gt; \&#34;${fpath[1]}/_kwctl\&#34;\n```\n\n##### Oh My Zsh users\n\nThese steps are required by [oh-my-zsh](https://ohmyz.sh/) users:\n\n```console\n$ print -l $fpath | grep &#39;.oh-my-zsh/completions&#39;\n$ mkdir ~/.oh-my-zsh/completions\n$ kwctl completions -s zsh &gt; ~/.oh-my-zsh/completions/_kwctl\nrm ~/.zcompdump*\n```\n\nThen start a new shell or run `source ~/.zshrc` once.\n\n## Verify kwctl binaries\n\nkwctl binaries are signed using [Sigstore&#39;s blog signing](https://docs.sigstore.dev/signing/signing_with_blobs/).\nWhen you download a [kwctl release](https://github.com/kubewarden/kwctl/releases/) each zip file contains two\nfiles that can be used for verification: `kwctl.sig` and `kwctl.pem`.\n\nIn order to verify kwctl you need cosign installed, and then execute the following command:\n\n```\ncosign verify-blob \\\n  --signature kwctl-linux-x86_64.sig \\\n  --cert kwctl-linux-x86_64.pem kwctl-linux-x86_64 \\\n  --certificate-identity-regexp &#39;https://github.com/kubewarden/*&#39; \\\n  --certificate-oidc-issuer https://token.actions.githubusercontent.com\n```\n\nThe output should be:\n\n```\nVerified OK\n```\n\n# Software bill of materials &amp; provenance\n\nKwctl has its software bill of materials (SBOM) published every release. They\nfollow the [SPDX](https://spdx.dev/) format, you can find them together with\nthe signature and certificate used to sign it in the [releases\nassets](https://github.com/kubewarden/kwctl/releases).\n\nThe build [Provenance](https://slsa.dev/spec/v1.0/provenance) files are\nfollowing the [SLSA](https://slsa.dev/provenance/v0.2#schema) provenance schema\nand are accesible at the GitHub Actions&#39;\n[provenance](https://github.com/kubewarden/kwctl/attestations) tab. For\ninformation on their format and how to verify them, see the [GitHub\ndocumentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-attestations-offline).\n\n## Security disclosure\n\nSee [SECURITY.md](https://github.com/kubewarden/community/blob/main/SECURITY.md) on the kubewarden/community repo.\n\n## Changelog\n\nSee [GitHub Releases content](https://github.com/kubewarden/kwctl/releases).\n&#34;:&#xA;&#x9;* docs/reference/kwctl-readme.md&#xA;</p>
        </details>
        <details id="6fe0cf36db9a3b2adba3096e23d58a0b3b212640dac14d5f70a715c49489498c">
            <summary>Updates file in target repository</summary>
            <p>1 file(s) updated with &#34;# Command-Line Help for `kwctl`\n\nThis document contains the help content for the `kwctl` command-line program.\n\n**Command Overview:**\n\n* [`kwctl`↴](#kwctl)\n* [`kwctl annotate`↴](#kwctl-annotate)\n* [`kwctl bench`↴](#kwctl-bench)\n* [`kwctl completions`↴](#kwctl-completions)\n* [`kwctl digest`↴](#kwctl-digest)\n* [`kwctl docs`↴](#kwctl-docs)\n* [`kwctl info`↴](#kwctl-info)\n* [`kwctl inspect`↴](#kwctl-inspect)\n* [`kwctl load`↴](#kwctl-load)\n* [`kwctl policies`↴](#kwctl-policies)\n* [`kwctl pull`↴](#kwctl-pull)\n* [`kwctl push`↴](#kwctl-push)\n* [`kwctl rm`↴](#kwctl-rm)\n* [`kwctl run`↴](#kwctl-run)\n* [`kwctl save`↴](#kwctl-save)\n* [`kwctl scaffold`↴](#kwctl-scaffold)\n* [`kwctl scaffold admission-request`↴](#kwctl-scaffold-admission-request)\n* [`kwctl scaffold artifacthub`↴](#kwctl-scaffold-artifacthub)\n* [`kwctl scaffold manifest`↴](#kwctl-scaffold-manifest)\n* [`kwctl scaffold vap`↴](#kwctl-scaffold-vap)\n* [`kwctl scaffold verification-config`↴](#kwctl-scaffold-verification-config)\n* [`kwctl verify`↴](#kwctl-verify)\n\n## `kwctl`\n\nTool to manage Kubewarden policies\n\n**Usage:** `kwctl [OPTIONS] &lt;COMMAND&gt;`\n\n###### **Subcommands:**\n\n* `annotate` — Add Kubewarden metadata to a WebAssembly module\n* `bench` — Benchmarks a Kubewarden policy\n* `completions` — Generate shell completions\n* `digest` — Fetch digest from the OCI manifest of a policy\n* `docs` — Generates the markdown documentation for kwctl commands\n* `info` — Display system information\n* `inspect` — Inspect Kubewarden policy\n* `load` — load policies from a tar.gz file\n* `policies` — Lists all downloaded policies\n* `pull` — Pulls a Kubewarden policy from a given URI\n* `push` — Pushes a Kubewarden policy to an OCI registry\n* `rm` — Removes a Kubewarden policy from the store\n* `run` — Runs a Kubewarden policy from a given URI\n* `save` — save policies to a tar.gz file\n* `scaffold` — Scaffold a Kubernetes resource or configuration file\n* `verify` — Verify a Kubewarden policy from a given URI using Sigstore\n\n###### **Options:**\n\n* `-v`, `--verbose &lt;VERBOSE&gt;` — Increase verbosity\n* `--no-color &lt;NO-COLOR&gt;` — Disable colorful output\n\n\n\n## `kwctl annotate`\n\nAdd Kubewarden metadata to a WebAssembly module\n\n**Usage:** `kwctl annotate [OPTIONS] --metadata-path &lt;PATH&gt; --output-path &lt;PATH&gt; &lt;wasm-path&gt;`\n\n###### **Arguments:**\n\n* `&lt;WASM-PATH&gt;` — Path to WebAssembly module to be annotated\n\n###### **Options:**\n\n* `-m`, `--metadata-path &lt;PATH&gt;` — File containing the metadata\n* `-o`, `--output-path &lt;PATH&gt;` — Output file\n* `-u`, `--usage-path &lt;PATH&gt;` — File containing the usage information of the policy\n\n\n\n## `kwctl bench`\n\nBenchmarks a Kubewarden policy\n\n**Usage:** `kwctl bench [OPTIONS] --request-path &lt;PATH&gt; &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--allow-context-aware &lt;ALLOW-CONTEXT-AWARE&gt;` — Grant access to the Kubernetes resources defined inside of the policy&#39;s `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--disable-wasmtime-cache &lt;DISABLE-WASMTIME-CACHE&gt;` — Turn off usage of wasmtime cache\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--dump-results-to-disk &lt;DUMP_RESULTS_TO_DISK&gt;` — Puts results in target/tiny-bench/label/.. if target can be found. used for comparing previous runs\n* `-e`, `--execution-mode &lt;MODE&gt;` — The runtime to use to execute this policy\n\n  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`\n\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--measurement-time &lt;SECONDS&gt;` — How long the bench ‘should’ run, num_samples is prioritized so benching will take longer to be able to collect num_samples if the code to be benched is slower than this time limit allowed\n* `--num-resamples &lt;NUM&gt;` — How many resamples should be done\n* `--num-samples &lt;NUM&gt;` — How many resamples should be done. Recommended at least 50, above 100 doesn’t seem to yield a significantly different result\n* `--raw &lt;RAW&gt;` — Validate a raw request\n\n  Default value: `false`\n* `--record-host-capabilities-interactions &lt;FILE&gt;` — Record all the policy and host capabilities\n   communications to the given file.\n   Useful to be combined later with &#39;--replay-host-capabilities-interactions&#39; flag\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key\n* `--replay-host-capabilities-interactions &lt;FILE&gt;` — During policy and host capabilities exchanges\n   the host replays back the answers found inside of the provided file.\n   This is useful to test policies in a reproducible way, given no external\n   interactions with OCI registries, DNS, Kubernetes are performed.\n* `-r`, `--request-path &lt;PATH&gt;` — File containing the Kubernetes admission request object in JSON format\n* `--settings-json &lt;VALUE&gt;` — JSON string containing the settings for this policy\n* `-s`, `--settings-path &lt;PATH&gt;` — File containing the settings for this policy\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n* `--warm-up-time &lt;SECONDS&gt;` — How long the bench should warm up\n\n\n\n## `kwctl completions`\n\nGenerate shell completions\n\n**Usage:** `kwctl completions --shell &lt;VALUE&gt;`\n\n###### **Options:**\n\n* `-s`, `--shell &lt;VALUE&gt;` — Shell type\n\n  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`\n\n\n\n\n## `kwctl digest`\n\nFetch digest from the OCI manifest of a policy\n\n**Usage:** `kwctl digest [OPTIONS] &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI&gt;` — Policy URI\n\n###### **Options:**\n\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n\n\n\n## `kwctl docs`\n\nGenerates the markdown documentation for kwctl commands\n\n**Usage:** `kwctl docs --output &lt;FILE&gt;`\n\n###### **Options:**\n\n* `-o`, `--output &lt;FILE&gt;` — path where the documentation file will be stored\n\n\n\n## `kwctl info`\n\nDisplay system information\n\n**Usage:** `kwctl info`\n\n\n\n## `kwctl inspect`\n\nInspect Kubewarden policy\n\n**Usage:** `kwctl inspect [OPTIONS] &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `-o`, `--output &lt;FORMAT&gt;` — Output format\n\n  Possible values: `yaml`\n\n* `--show-signatures &lt;SHOW-SIGNATURES&gt;` — Show sigstore signatures\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n\n\n\n## `kwctl load`\n\nload policies from a tar.gz file\n\n**Usage:** `kwctl load --input &lt;input&gt;`\n\n###### **Options:**\n\n* `--input &lt;INPUT&gt;` — load policies from tarball\n\n\n\n## `kwctl policies`\n\nLists all downloaded policies\n\n**Usage:** `kwctl policies`\n\n\n\n## `kwctl pull`\n\nPulls a Kubewarden policy from a given URI\n\n**Usage:** `kwctl pull [OPTIONS] &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI&gt;` — Policy URI. Supported schemes: registry://, https://, file://\n\n###### **Options:**\n\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--docker-config-json-path &lt;DOCKER_CONFIG&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `-o`, `--output-path &lt;PATH&gt;` — Output file. If not provided will be downloaded to the Kubewarden store\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key. Can be repeated multiple times\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n## `kwctl push`\n\nPushes a Kubewarden policy to an OCI registry\n\n**Usage:** `kwctl push [OPTIONS] &lt;policy&gt; &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;POLICY&gt;` — Policy to push. Can be the path to a local file, a policy URI or the SHA prefix of a policy in the store.\n* `&lt;URI&gt;` — Policy URI. Supported schemes: registry://\n\n###### **Options:**\n\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `-f`, `--force &lt;FORCE&gt;` — Push also a policy that is not annotated\n* `-o`, `--output &lt;PATH&gt;` — Output format\n\n  Default value: `text`\n\n  Possible values: `text`, `json`\n\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n\n\n\n## `kwctl rm`\n\nRemoves a Kubewarden policy from the store\n\n**Usage:** `kwctl rm &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix\n\n\n\n## `kwctl run`\n\nRuns a Kubewarden policy from a given URI\n\n**Usage:** `kwctl run [OPTIONS] --request-path &lt;PATH&gt; &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--allow-context-aware &lt;ALLOW-CONTEXT-AWARE&gt;` — Grant access to the Kubernetes resources defined inside of the policy&#39;s `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--disable-wasmtime-cache &lt;DISABLE-WASMTIME-CACHE&gt;` — Turn off usage of wasmtime cache\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `-e`, `--execution-mode &lt;MODE&gt;` — The runtime to use to execute this policy\n\n  Possible values: `opa`, `gatekeeper`, `kubewarden`, `wasi`\n\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--raw &lt;RAW&gt;` — Validate a raw request\n\n  Default value: `false`\n* `--record-host-capabilities-interactions &lt;FILE&gt;` — Record all the policy and host capabilities\n   communications to the given file.\n   Useful to be combined later with &#39;--replay-host-capabilities-interactions&#39; flag\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key\n* `--replay-host-capabilities-interactions &lt;FILE&gt;` — During policy and host capabilities exchanges\n   the host replays back the answers found inside of the provided file.\n   This is useful to test policies in a reproducible way, given no external\n   interactions with OCI registries, DNS, Kubernetes are performed.\n* `-r`, `--request-path &lt;PATH&gt;` — File containing the Kubernetes admission request object in JSON format\n* `--settings-json &lt;VALUE&gt;` — JSON string containing the settings for this policy\n* `-s`, `--settings-path &lt;PATH&gt;` — File containing the settings for this policy\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n## `kwctl save`\n\nsave policies to a tar.gz file\n\n**Usage:** `kwctl save --output &lt;FILE&gt; &lt;policies&gt;...`\n\n###### **Arguments:**\n\n* `&lt;POLICIES&gt;` — list of policies to save\n\n###### **Options:**\n\n* `-o`, `--output &lt;FILE&gt;` — path where the file will be stored\n\n\n\n## `kwctl scaffold`\n\nScaffold a Kubernetes resource or configuration file\n\n**Usage:** `kwctl scaffold &lt;COMMAND&gt;`\n\n###### **Subcommands:**\n\n* `admission-request` — Scaffold an AdmissionRequest object\n* `artifacthub` — Output an artifacthub-pkg.yml file from a metadata.yml file\n* `manifest` — Output a Kubernetes resource manifest\n* `vap` — Convert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`\n* `verification-config` — Output a default Sigstore verification configuration file\n\n\n\n## `kwctl scaffold admission-request`\n\nScaffold an AdmissionRequest object\n\n**Usage:** `kwctl scaffold admission-request [OPTIONS] --operation &lt;TYPE&gt;`\n\n###### **Options:**\n\n* `--object &lt;PATH&gt;` — The file containing the new object being admitted\n* `--old-object &lt;PATH&gt;` — The file containing the existing object\n* `-o`, `--operation &lt;TYPE&gt;` — Kubewarden Custom Resource type\n\n  Possible values: `CREATE`\n\n\n\n\n## `kwctl scaffold artifacthub`\n\nOutput an artifacthub-pkg.yml file from a metadata.yml file\n\n**Usage:** `kwctl scaffold artifacthub [OPTIONS] --metadata-path &lt;PATH&gt; --version &lt;VALUE&gt;`\n\n###### **Options:**\n\n* `-m`, `--metadata-path &lt;PATH&gt;` — File containing the metadata of the policy\n* `-o`, `--output &lt;FILE&gt;` — Path where the artifact-pkg.yml file will be stored\n* `-q`, `--questions-path &lt;PATH&gt;` — File containing the questions-ui content of the policy\n* `-v`, `--version &lt;VALUE&gt;` — Semver version of the policy\n\n\n\n## `kwctl scaffold manifest`\n\nOutput a Kubernetes resource manifest\n\n**Usage:** `kwctl scaffold manifest [OPTIONS] --type &lt;VALUE&gt; &lt;uri_or_sha_prefix&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI_OR_SHA_PREFIX&gt;` — Policy URI or SHA prefix. Supported schemes: registry://, https://, file://. If schema is omitted, file:// is assumed, rooted on the current directory.\n\n###### **Options:**\n\n* `--allow-context-aware &lt;ALLOW-CONTEXT-AWARE&gt;` — Uses the policy metadata to define which Kubernetes resources can be accessed by the policy. Warning: review the list of resources carefully to avoid abuses. Disabled by default\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--docker-config-json-path &lt;DOCKER_CONFIG&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key. Can be repeated multiple times\n* `--settings-json &lt;VALUE&gt;` — JSON string containing the settings for this policy\n* `-s`, `--settings-path &lt;PATH&gt;` — File containing the settings for this policy\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `--title &lt;VALUE&gt;` — Policy title\n* `-t`, `--type &lt;VALUE&gt;` — Kubewarden Custom Resource type\n\n  Possible values: `ClusterAdmissionPolicy`, `AdmissionPolicy`\n\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n## `kwctl scaffold vap`\n\nConvert a Kubernetes `ValidatingAdmissionPolicy` into a Kubewarden `ClusterAdmissionPolicy`\n\n**Usage:** `kwctl scaffold vap [OPTIONS] --binding &lt;VALIDATING-ADMISSION-POLICY-BINDING.yaml&gt; --policy &lt;VALIDATING-ADMISSION-POLICY.yaml&gt;`\n\n###### **Options:**\n\n* `-b`, `--binding &lt;VALIDATING-ADMISSION-POLICY-BINDING.yaml&gt;` — The file containining the ValidatingAdmissionPolicyBinding definition\n* `--cel-policy &lt;URI&gt;` — The CEL policy module to use\n\n  Default value: `ghcr.io/kubewarden/policies/cel-policy:latest`\n* `-p`, `--policy &lt;VALIDATING-ADMISSION-POLICY.yaml&gt;` — The file containining the ValidatingAdmissionPolicy definition\n\n\n\n## `kwctl scaffold verification-config`\n\nOutput a default Sigstore verification configuration file\n\n**Usage:** `kwctl scaffold verification-config`\n\n\n\n## `kwctl verify`\n\nVerify a Kubewarden policy from a given URI using Sigstore\n\n**Usage:** `kwctl verify [OPTIONS] &lt;uri&gt;`\n\n###### **Arguments:**\n\n* `&lt;URI&gt;` — Policy URI. Supported schemes: registry://\n\n###### **Options:**\n\n* `--cert-email &lt;VALUE&gt;` — Expected email in Fulcio certificate\n* `--cert-oidc-issuer &lt;VALUE&gt;` — Expected OIDC issuer in Fulcio certificates\n* `--docker-config-json-path &lt;PATH&gt;` — Path to a directory containing the Docker &#39;config.json&#39; file. Can be used to indicate registry authentication details\n* `--fulcio-cert-path &lt;PATH&gt;` — Path to the Fulcio certificate. Can be repeated multiple times\n* `--github-owner &lt;VALUE&gt;` — GitHub owner expected in the certificates generated in CD pipelines\n* `--github-repo &lt;VALUE&gt;` — GitHub repository expected in the certificates generated in CD pipelines\n* `--rekor-public-key-path &lt;PATH&gt;` — Path to the Rekor public key\n* `--sources-path &lt;PATH&gt;` — YAML file holding source information (https, registry insecure hosts, custom CA&#39;s...)\n* `-a`, `--verification-annotation &lt;KEY=VALUE&gt;` — Annotation in key=value format. Can be repeated multiple times\n* `--verification-config-path &lt;PATH&gt;` — YAML file holding verification config information (signatures, public keys...)\n* `-k`, `--verification-key &lt;PATH&gt;` — Path to key used to verify the policy. Can be repeated multiple times\n\n\n\n&lt;hr/&gt;\n\n&lt;small&gt;&lt;i&gt;\n    This document was generated automatically by\n    &lt;a href=\&#34;https://crates.io/crates/clap-markdown\&#34;&gt;&lt;code&gt;clap-markdown&lt;/code&gt;&lt;/a&gt;.\n&lt;/i&gt;&lt;/small&gt;\n&#34;:&#xA;&#x9;* docs/reference/kwctl-cli.md&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

